### PR TITLE
feat(metrics): split savings into monotonic totalSavings and truthful totalCostImpact

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,9 @@
+export interface OrchestratorMetrics {
+  totalSavings: number;      // SEK, monotonically increasing
+  totalCostImpact: number;   // SEK, can be +/-
+  dailyCostImpact?: number;  // SEK, same-day sum of costDelta
+  dailyCostImpactDate?: string; // YYYY-MM-DD for reset
+  kWhShifted?: number;
+  peakAvoidedKw?: number;
+  lastUpdateIso?: string;
+}

--- a/src/util/timeline-helper.ts
+++ b/src/util/timeline-helper.ts
@@ -385,9 +385,7 @@ export class TimelineHelper {
               message += `. Today so far: €${Number(additionalData.todaySoFar).toFixed(2)}`;
               this.logger.error('Error formatting currency:', error);
             }
-          }
-          // Otherwise, fall back to projected daily savings (legacy behaviour)
-          else if (additionalData.dailySavings !== undefined || additionalData.savings !== undefined) {
+          } else if (additionalData.dailySavings !== undefined || additionalData.savings !== undefined) {
             try {
               // Get the user's locale or default to the system locale
               const userLocale = this.homey.i18n?.getLanguage() || 'en-US';
@@ -416,6 +414,23 @@ export class TimelineHelper {
                 (additionalData.savings * 24);
               message += `. Projected daily savings: €${savingsAmount.toFixed(2)}`;
               this.logger.error('Error formatting currency:', error);
+            }
+          }
+
+          if (additionalData.costImpactToday !== undefined) {
+            try {
+              const userLocale = this.homey.i18n?.getLanguage() || 'en-US';
+              const userCurrency = CurrencyDetector.getCurrencyWithFallback(this.homey);
+              const formattedImpact = new Intl.NumberFormat(userLocale, {
+                style: 'currency',
+                currency: userCurrency,
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
+              }).format(additionalData.costImpactToday);
+              message += `. Cost impact today: ${formattedImpact}`;
+            } catch (error) {
+              message += `. Cost impact today: €${Number(additionalData.costImpactToday).toFixed(2)}`;
+              this.logger.error('Error formatting currency for cost impact:', error);
             }
           }
         } else if (eventType === TimelineEventType.WEEKLY_CALIBRATION_RESULT) {


### PR DESCRIPTION
## Summary
- track cumulative savings and cost deltas via new `OrchestratorMetrics`
- add accounting step that clamps negative savings while persisting total cost impact
- log cost impact and expose daily cost impact in timeline entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5e43956ec83329716afb2d477d8ca