### PR TITLE
fix: surgical remediation of season/DHW/COP audit findings

### DIFF
--- a/src/services/cop-helper.ts
+++ b/src/services/cop-helper.ts
@@ -86,18 +86,32 @@ export class COPHelper {
     try {
       this.logger.log(`Computing ${timeframe} COP values`);
 
-      // Get MELCloud data from the optimizer
-      const melData = await this.getMELCloudData();
-      if (!melData || !melData.Device) {
-        this.logger.error('No MELCloud data available for COP calculation');
-        return;
-      }
+      // Prefer the accurate EnergyCost/Report aggregates (the same source the live optimizer trusts).
+      // The Device/Get DailyHeating/HotWaterEnergyProduced/Consumed fields read 0 on some units,
+      // which previously made every persisted COP snapshot/weekly-trend 0 (DHW-2). Fall back to the
+      // device-state daily counters only if the totals fetch is unavailable.
+      let producedHeating: number;
+      let consumedHeating: number;
+      let producedHW: number;
+      let consumedHW: number;
 
-      // Extract energy figures – values are kWh for the period up to now
-      const producedHeating = melData.Device.DailyHeatingEnergyProduced || 0;
-      const consumedHeating = melData.Device.DailyHeatingEnergyConsumed || 0;
-      const producedHW = melData.Device.DailyHotWaterEnergyProduced || 0;
-      const consumedHW = melData.Device.DailyHotWaterEnergyConsumed || 0;
+      const totals = await this.getEnergyTotals();
+      if (totals) {
+        producedHeating = totals.TotalHeatingProduced || 0;
+        consumedHeating = totals.TotalHeatingConsumed || 0;
+        producedHW = totals.TotalHotWaterProduced || 0;
+        consumedHW = totals.TotalHotWaterConsumed || 0;
+      } else {
+        const melData = await this.getMELCloudData();
+        if (!melData || !melData.Device) {
+          this.logger.error('No MELCloud data available for COP calculation');
+          return;
+        }
+        producedHeating = melData.Device.DailyHeatingEnergyProduced || 0;
+        consumedHeating = melData.Device.DailyHeatingEnergyConsumed || 0;
+        producedHW = melData.Device.DailyHotWaterEnergyProduced || 0;
+        consumedHW = melData.Device.DailyHotWaterEnergyConsumed || 0;
+      }
 
       // Safety – avoid division by zero
       const copHeat = consumedHeating > 0 ? producedHeating / consumedHeating : 0;
@@ -116,6 +130,32 @@ export class COPHelper {
       this.logger.log(`- Hot Water: Produced ${producedHW.toFixed(2)} kWh, Consumed ${consumedHW.toFixed(2)} kWh, COP ${copHW.toFixed(2)}`);
     } catch (error: unknown) {
       this.logger.error(`Error computing ${timeframe} COP:`, error);
+    }
+  }
+
+  /**
+   * Get accurate daily energy totals from the EnergyCost/Report aggregates.
+   * This is the same source the live optimizer uses, and unlike the Device/Get daily
+   * counters it reports real produced/consumed figures on all units.
+   * @returns Daily energy totals, or null if unavailable
+   */
+  private async getEnergyTotals(): Promise<any | null> {
+    try {
+      const deviceId = this.homey.settings.get('device_id');
+      const buildingId = parseInt(this.homey.settings.get('building_id') || '0');
+      if (!deviceId || !buildingId) {
+        return null;
+      }
+
+      const melCloud = (global as any).melCloud;
+      if (!melCloud || typeof melCloud.getDailyEnergyTotals !== 'function') {
+        return null;
+      }
+
+      return await melCloud.getDailyEnergyTotals(deviceId, buildingId);
+    } catch (error: unknown) {
+      this.logger.error('Error getting energy totals for COP calculation:', error);
+      return null;
     }
   }
 

--- a/src/services/energy-metrics-service.ts
+++ b/src/services/energy-metrics-service.ts
@@ -36,6 +36,12 @@ export interface EnergyMetricsLogger {
 export const ENERGY_METRICS_CONFIG = {
   /** Minimum heating consumption (kWh) to consider winter mode */
   MIN_HEATING_FOR_WINTER: 1.0,
+  /**
+   * Minimum heating energy PRODUCED (kWh) for the unit to be considered heating at all.
+   * Below this the pump produces ~no useful heat (only standby/parasitic draw), so the season
+   * is summer regardless of consumed electricity. Prevents being stuck in "transition" all summer.
+   */
+  MIN_HEATING_PRODUCED_FOR_SEASON: 0.5,
   /** Ratio of heating to hot water for winter classification */
   HEATING_DOMINANT_RATIO: 2.0,
   /** Default efficiency fallback divisor for basic normalization */
@@ -211,7 +217,7 @@ export class EnergyMetricsService {
         : hotWaterEfficiencyRaw;
 
       // Determine seasonal mode and optimization focus
-      const seasonalMode = this.determineSeason(heatingConsumed, hotWaterConsumed);
+      const seasonalMode = this.determineSeason(heatingConsumed, hotWaterConsumed, heatingProduced);
       const optimizationFocus = this.determineOptimizationFocus(
         enhancedCOPData.trends,
         seasonalMode,
@@ -273,7 +279,20 @@ export class EnergyMetricsService {
    * @param hotWaterConsumed Total hot water energy consumed (kWh)
    * @returns Seasonal mode (summer/winter/transition)
    */
-  determineSeason(heatingConsumed: number, hotWaterConsumed: number): SeasonalMode {
+  determineSeason(
+    heatingConsumed: number,
+    hotWaterConsumed: number,
+    heatingProduced?: number
+  ): SeasonalMode {
+    // Root-cause guard: if the pump produces ~no heat, it's summer even when standby/parasitic
+    // electricity keeps heatingConsumed above the winter threshold. Skipped when heatingProduced
+    // is unknown (undefined) to preserve legacy behavior.
+    if (
+      heatingProduced !== undefined &&
+      heatingProduced < ENERGY_METRICS_CONFIG.MIN_HEATING_PRODUCED_FOR_SEASON
+    ) {
+      return 'summer';
+    }
     if (heatingConsumed < ENERGY_METRICS_CONFIG.MIN_HEATING_FOR_WINTER) {
       // Less than 1 kWh heating in 7 days = summer
       return 'summer';
@@ -385,8 +404,9 @@ export class EnergyMetricsService {
       const energyData = await this.melCloud.getDailyEnergyTotals(deviceId, buildingId);
 
       const heatingConsumed = energyData.TotalHeatingConsumed || 0;
+      const heatingProduced = energyData.TotalHeatingProduced || 0;
       const hotWaterConsumed = energyData.TotalHotWaterConsumed || 0;
-      
+
       // Prefer explicit fields if present, then averageCOP, then legacy Average* fields
       const realHeatingCOP = Number(
         energyData.heatingCOP ?? energyData.averageCOP ?? energyData.AverageHeatingCOP ?? 0
@@ -402,7 +422,7 @@ export class EnergyMetricsService {
 
       this.logger.log('Using fallback energy metrics calculation');
 
-      const seasonalMode = this.determineSeason(heatingConsumed, hotWaterConsumed);
+      const seasonalMode = this.determineSeason(heatingConsumed, hotWaterConsumed, heatingProduced);
 
       return {
         realHeatingCOP,

--- a/src/services/hot-water-optimizer.ts
+++ b/src/services/hot-water-optimizer.ts
@@ -603,12 +603,18 @@ export class HotWaterOptimizer {
 
             // Determine current action
             let currentAction: 'heat_now' | 'delay' | 'maintain' = 'maintain';
+            // Reason that reflects what actually drove the decision (Fix 6). Previously a single
+            // "Predictive scheduling…" template was returned for every branch, so a price-driven
+            // delay was mislabeled as predictive scheduling.
+            let actionReason = 'Holding tank setpoint (no immediate action)';
+            const peaksStr = usagePattern.peakHours.join(', ');
 
             // Check if current hour is a scheduled heating time
             const isScheduledNow = schedulePoints.some(point => point.hour === currentHour);
 
             if (isScheduledNow) {
                 currentAction = 'heat_now';
+                actionReason = `Pre-heating in scheduled cheap window ahead of usage peaks (${peaksStr}h)`;
             } else {
                 // Check if we're approaching a peak and haven't heated yet
                 const nextPeak = usagePattern.peakHours.find(peak => {
@@ -619,10 +625,12 @@ export class HotWaterOptimizer {
                 if (nextPeak && hotWaterCOP > 0) {
                     // Emergency heating before peak
                     currentAction = 'heat_now';
+                    actionReason = `Pre-heating: usage peak within 2h (peak at ${nextPeak}h)`;
                 } else {
                     // Check if current price is exceptional
                     const currentPrice = Number.isFinite(next24h[0]?.price) ? next24h[0].price : 0;
                     const avgPrice = next24h.reduce((sum: number, p: any) => sum + (Number.isFinite(p.price) ? p.price : 0), 0) / next24h.length;
+                    const priceRatio = avgPrice > 0 ? currentPrice / avgPrice : 1;
 
                     // Convert user's cheap percentile to price ratio threshold
                     const priceRatioThreshold = 1.0 - (this.priceAnalyzer.getCheapPercentile() * 1.2);
@@ -631,9 +639,13 @@ export class HotWaterOptimizer {
                     const normalizedHWCOP = CopNormalizer.roughNormalize(hotWaterCOP, 4.0);
                     if (currentPrice < avgPrice * priceRatioThreshold && normalizedHWCOP > COP_THRESHOLDS.GOOD) {
                         currentAction = 'heat_now';
+                        actionReason = `Heating now: price low (${priceRatio.toFixed(2)}× avg) and COP favourable`;
                     } else if (currentPrice > avgPrice * (1 + this.priceAnalyzer.getCheapPercentile() * 1.2)) {
                         // Expensive hour: reduce tank to save energy, heat later at cheaper price
                         currentAction = 'delay';
+                        actionReason = `Conserving tank: price high (${priceRatio.toFixed(2)}× avg), reheat later at cheaper price`;
+                    } else {
+                        actionReason = `Holding tank setpoint (price ${priceRatio.toFixed(2)}× avg, near normal)`;
                     }
                 }
             }
@@ -662,7 +674,9 @@ export class HotWaterOptimizer {
             return {
                 schedulePoints,
                 currentAction,
-                reasoning: `Predictive scheduling based on usage pattern (peaks: ${usagePattern.peakHours.join(', ')}h, saves ${estimatedSavings.toFixed(2)} ${currencyCode})`,
+                reasoning: currentAction === 'maintain'
+                    ? actionReason
+                    : `${actionReason} (peaks: ${peaksStr}h, saves ${estimatedSavings.toFixed(2)} ${currencyCode})`,
                 estimatedSavings
             };
 

--- a/src/services/melcloud-api.ts
+++ b/src/services/melcloud-api.ts
@@ -645,24 +645,34 @@ export class MelCloudApi extends BaseApiService {
    */
   async getWeeklyAverageCOP(deviceId: string, buildingId: number): Promise<{ heating: number; hotWater: number }> {
     try {
-      // Get device state to access energy data
-      const deviceState = await this.getDeviceState(deviceId, buildingId);
+      // Prefer the accurate EnergyCost/Report aggregates. The instantaneous device-state Daily*
+      // fields read 0 on some units, which previously made this endpoint always return 0 (DHW-2).
+      let producedHeating = 0;
+      let consumedHeating = 0;
+      let producedHW = 0;
+      let consumedHW = 0;
 
-      // Calculate COP for heating
-      let heatingCOP = 0;
-      if (deviceState.DailyHeatingEnergyProduced && deviceState.DailyHeatingEnergyConsumed) {
-        if (deviceState.DailyHeatingEnergyConsumed > 0) {
-          heatingCOP = deviceState.DailyHeatingEnergyProduced / deviceState.DailyHeatingEnergyConsumed;
-        }
+      try {
+        const totals = await this.getDailyEnergyTotals(deviceId, buildingId);
+        producedHeating = totals?.TotalHeatingProduced || 0;
+        consumedHeating = totals?.TotalHeatingConsumed || 0;
+        producedHW = totals?.TotalHotWaterProduced || 0;
+        consumedHW = totals?.TotalHotWaterConsumed || 0;
+      } catch {
+        // fall through to device-state below
       }
 
-      // Calculate COP for hot water
-      let hotWaterCOP = 0;
-      if (deviceState.DailyHotWaterEnergyProduced && deviceState.DailyHotWaterEnergyConsumed) {
-        if (deviceState.DailyHotWaterEnergyConsumed > 0) {
-          hotWaterCOP = deviceState.DailyHotWaterEnergyProduced / deviceState.DailyHotWaterEnergyConsumed;
-        }
+      // Fallback to instantaneous device-state daily counters when totals are unavailable.
+      if (consumedHeating <= 0 && consumedHW <= 0) {
+        const deviceState = await this.getDeviceState(deviceId, buildingId);
+        producedHeating = deviceState.DailyHeatingEnergyProduced || 0;
+        consumedHeating = deviceState.DailyHeatingEnergyConsumed || 0;
+        producedHW = deviceState.DailyHotWaterEnergyProduced || 0;
+        consumedHW = deviceState.DailyHotWaterEnergyConsumed || 0;
       }
+
+      const heatingCOP = consumedHeating > 0 ? producedHeating / consumedHeating : 0;
+      const hotWaterCOP = consumedHW > 0 ? producedHW / consumedHW : 0;
 
       this.logger.log(`Weekly average COP for device ${deviceId}: Heating=${heatingCOP.toFixed(2)}, Hot Water=${hotWaterCOP.toFixed(2)}`);
 

--- a/src/services/optimizer.ts
+++ b/src/services/optimizer.ts
@@ -121,6 +121,8 @@ interface Zone1OptimizationResult {
   lockoutActive: boolean;
   changed: boolean;
   needsApply: boolean;
+  /** True when the write was suppressed because the room is above the comfort band (no heat possible). */
+  heatDemandHold?: boolean;
   priceNormalized: number;
   weatherInfo?: WeatherInfo | null;
   planningBias?: number;
@@ -1695,6 +1697,18 @@ export class Optimizer {
     );
     this.logger.log('Enhanced optimization result:', logData);
 
+    // Heat-demand gate (Fix 4): when the room sits above the controllable comfort band (e.g. solar
+    // gain in summer), every clamped setpoint is <= maxTemp < room, so it cannot call for heat —
+    // applying a new zone1 setpoint is physically a no-op and only causes pointless MELCloud churn.
+    // This is inert during heating season: the room is within/below the band whenever the pump can
+    // actually heat, so the gate never blocks a real adjustment.
+    const roomAboveBand =
+      Number.isFinite(currentTemp as number) && (currentTemp as number) > constraintsBand.maxTemp;
+    if (roomAboveBand) {
+      const idleNote = deviceState?.IdleZone1 === true ? ', zone1 idle' : '';
+      adjustmentReason += ` | Room ${(currentTemp as number).toFixed(1)}°C above comfort band ${constraintsBand.maxTemp}°C${idleNote} — setpoint has no effect, holding`;
+    }
+
     return {
       targetTemp,
       reason: adjustmentReason,
@@ -1707,7 +1721,8 @@ export class Optimizer {
       duplicateTarget,
       lockoutActive,
       changed: zone1FinalConstraints.changed,
-      needsApply: zone1FinalConstraints.changed && !zone1FinalConstraints.lockoutActive && !duplicateTarget,
+      needsApply: zone1FinalConstraints.changed && !zone1FinalConstraints.lockoutActive && !duplicateTarget && !roomAboveBand,
+      heatDemandHold: roomAboveBand,
       priceNormalized: priceNormalizedValue,
       weatherInfo,
       planningBias: scaledPlanningBias,
@@ -2158,7 +2173,9 @@ export class Optimizer {
           ? `Setpoint change lockout(${this.minSetpointChangeMinutes}m) to prevent cycling`
           : zone1Result.duplicateTarget
             ? 'Duplicate target – already applied recently'
-            : `Temperature difference ${zone1Result.tempDifference.toFixed(1)}°C below deadband ${this.getZone1Constraints().deadband}°C`;
+            : zone1Result.heatDemandHold
+              ? 'Room above comfort band — setpoint has no effect (no heat demand)'
+              : `Temperature difference ${zone1Result.tempDifference.toFixed(1)}°C below deadband ${this.getZone1Constraints().deadband}°C`;
     }
 
     if (!changes.zone1Applied && changes.zone1HoldReason) {
@@ -2172,6 +2189,13 @@ export class Optimizer {
         changes.tankApplied = true;
 
         this.stateManager.recordTankChange(tankResult.toTemp, tankResult.evaluatedAtMs ?? Date.now());
+
+        // Persist tank lockout timestamp immediately. In summer zone1 never applies, so without
+        // this a tank-only change is never written to settings and the anti-cycling lockout is
+        // lost on restart (allowing a 2nd tank change within the hour). Mirrors the zone1 path above.
+        if (this.homey) {
+          this.stateManager.saveToSettings(this.homey);
+        }
 
         logger('tank.applied', {
           fromTemp: tankResult.fromTemp,

--- a/src/services/temperature-optimizer.ts
+++ b/src/services/temperature-optimizer.ts
@@ -467,15 +467,21 @@ export class TemperatureOptimizer {
       const priceAdjustment = (0.5 - normalizedPrice) * tempRange * priceWeight;
 
       // Combined efficiency adjustment
+      // Only penalize on low efficiency when the COP is actually measured. When heatingProduced=0
+      // (e.g. no space heating in summer), realHeatingCOP is 0 — that is a non-measurement, not poor
+      // performance, so applying the −0.4°C reduction would bias the setpoint down for no reason.
+      const copMeasured = metrics.realHeatingCOP > 0;
       let efficiencyAdjustment = 0;
       if (combinedEfficiency > TRANSITION_EFFICIENCY_HIGH) {
         efficiencyAdjustment = adaptiveParams?.copEfficiencyBonusMedium || DEFAULT_WEIGHTS.COP_EFFICIENCY_BONUS_MEDIUM;
-      } else if (combinedEfficiency < TRANSITION_EFFICIENCY_LOW) {
+      } else if (combinedEfficiency < TRANSITION_EFFICIENCY_LOW && copMeasured) {
         efficiencyAdjustment = TRANSITION_EFFICIENCY_REDUCTION;
       }
 
       targetTemp = midTemp + priceAdjustment + efficiencyAdjustment;
-      reason = `Transition mode: Combined COP efficiency ${(combinedEfficiency * 100).toFixed(0)}%, adapting to both heating and hot water needs`;
+      reason = copMeasured
+        ? `Transition mode: Combined COP efficiency ${(combinedEfficiency * 100).toFixed(0)}%, adapting to both heating and hot water needs`
+        : `Transition mode: heating COP unmeasured (no recent heat output), price-driven only`;
     }
 
     // COP-based fine-tuning removed: the per-season blocks above (summer/winter/transition)

--- a/test/unit/cop-helper.test.ts
+++ b/test/unit/cop-helper.test.ts
@@ -370,6 +370,34 @@ describe('COPHelper', () => {
       expect(mockLogger.log).toHaveBeenCalledWith('Daily COP values:');
     });
 
+    it('should prefer EnergyCost/Report totals over the (often-zero) device-state daily counters', async () => {
+      // Regression for DHW-2: device-state Daily* fields read 0 on some units, zeroing all history.
+      // The totals path returns the real produced/consumed (e.g. hotWater 5.273/1.794 -> COP 2.94).
+      jest.spyOn(copHelper as any, 'getEnergyTotals').mockResolvedValue({
+        TotalHeatingProduced: 0,
+        TotalHeatingConsumed: 1.527,
+        TotalHotWaterProduced: 5.273,
+        TotalHotWaterConsumed: 1.794
+      });
+      // Device-state path would yield zeros; ensure it is NOT used when totals exist.
+      const melDataSpy = jest.spyOn(copHelper as any, 'getMELCloudData').mockResolvedValue({
+        Device: {
+          DailyHeatingEnergyProduced: 0,
+          DailyHeatingEnergyConsumed: 0,
+          DailyHotWaterEnergyProduced: 0,
+          DailyHotWaterEnergyConsumed: 0
+        }
+      });
+      jest.spyOn(copHelper as any, 'pushSnapshot').mockResolvedValue(undefined);
+
+      await copHelper.compute('daily');
+
+      expect(melDataSpy).not.toHaveBeenCalled();
+      const snapshot = (copHelper as any).pushSnapshot.mock.calls[0][1];
+      expect(snapshot.water.cop).toBeCloseTo(2.94, 2);
+      expect(snapshot.heat.cop).toBe(0); // 0 produced -> COP 0 (correct, not a bug)
+    });
+
     it('should handle missing MELCloud data', async () => {
       // Mock getMELCloudData to return null
       jest.spyOn(copHelper as any, 'getMELCloudData').mockResolvedValue(null);

--- a/test/unit/energy-metrics-service.test.ts
+++ b/test/unit/energy-metrics-service.test.ts
@@ -285,6 +285,23 @@ describe('EnergyMetricsService', () => {
       );
       expect(belowThreshold).toBe('summer');
     });
+
+    it('should return summer when no heat is produced even if standby keeps consumption above threshold', () => {
+      // Live June case: 1.527 kWh consumed (standby), 0 produced, 1.794 hot water -> was stuck "transition".
+      const result = service.determineSeason(1.527, 1.794, 0);
+      expect(result).toBe('summer');
+    });
+
+    it('should preserve legacy classification when heatingProduced is omitted', () => {
+      // Same consumed/hotwater as above but no produced arg -> old behavior (transition).
+      expect(service.determineSeason(1.527, 1.794)).toBe('transition');
+    });
+
+    it('should NOT force summer in a genuine shoulder period with real heat output', () => {
+      // Real heating happening (produced above the floor) -> classifier unaffected by the guard.
+      const result = service.determineSeason(8, 5, 6);
+      expect(result).toBe('transition');
+    });
   });
 
   describe('determineOptimizationFocus', () => {

--- a/test/unit/hot-water-optimizer.test.ts
+++ b/test/unit/hot-water-optimizer.test.ts
@@ -540,6 +540,33 @@ describe('HotWaterOptimizer', () => {
       expect(result.reasoning).toContain('saves');
       expect(result.reasoning).toContain('NOK');
     });
+
+    test('reasoning reflects a price-driven delay rather than the generic predictive template (Fix 6)', () => {
+      // Expensive current hour, peak far away -> action should be 'delay' with price wording.
+      // next24h[0] is the first array element (the "now" price), so make element 0 expensive.
+      const priceData = Array.from({ length: 24 }, (_, i) => ({
+        hour: i,
+        time: `${i}:00`,
+        price: i === 0 ? 2.0 : 0.6
+      }));
+      const usagePattern = {
+        peakHours: [8], // far from current hour 20
+        hourlyDemand: Array(24).fill(0.1).map((v, i) => (i === 8 ? 0.8 : v))
+      };
+
+      const result = hotWaterOptimizer.optimizeHotWaterSchedulingByPattern(
+        20, // current hour: expensive, no peak within 2h
+        priceData,
+        3.0,
+        usagePattern,
+        undefined,
+        { currencyCode: 'NOK', estimatedDailyHotWaterKwh: 2 }
+      );
+
+      expect(result.currentAction).toBe('delay');
+      expect(result.reasoning).toMatch(/conserving tank|price high/i);
+      expect(result.reasoning).not.toMatch(/Predictive scheduling based on usage pattern/);
+    });
   });
 
   test('optimizeHotWaterSchedulingByPattern keeps late-evening peaks in the next-day planning window', () => {

--- a/test/unit/optimizer.enhanced.coverage.test.ts
+++ b/test/unit/optimizer.enhanced.coverage.test.ts
@@ -141,6 +141,92 @@ describe('Optimizer hotwater & enhanced edge cases', () => {
     expect(result.tankData).toBeDefined();
   });
 
+  describe('heat-demand gate (Fix 4)', () => {
+    // Prices that want a preheat: current hour cheapest, rest expensive -> target rises to band max.
+    const preheatPrices = () => {
+      const nowIso = new Date().toISOString();
+      return {
+        current: { price: 0.1, time: nowIso },
+        prices: new Array(24).fill(0).map((_, i) => ({
+          price: i === 0 ? 0.1 : 1.5,
+          time: new Date(Date.now() + i * 3600000).toISOString()
+        })),
+        priceLevel: 'CHEAP'
+      };
+    };
+
+    test('holds zone1 write when room is above the comfort band (no heat possible)', async () => {
+      optimizer.setTemperatureConstraints(18, 22, 0.5);
+      mockTibber.getPrices.mockResolvedValue(preheatPrices());
+      mockMel.getDeviceState.mockResolvedValue({
+        RoomTemperature: 26,           // well above band max 22 (solar gain)
+        RoomTemperatureZone1: 26,
+        SetTemperature: 20,
+        SetTemperatureZone1: 20,
+        OutdoorTemperature: 24,
+        IdleZone1: true
+      });
+
+      const result = await optimizer.runOptimization();
+
+      expect(mockMel.setDeviceTemperature).not.toHaveBeenCalled();
+      expect(result.reason).toMatch(/above comfort band/i);
+    });
+
+    test('control: same price scenario DOES apply when room is within the band', async () => {
+      optimizer.setTemperatureConstraints(18, 22, 0.5);
+      mockTibber.getPrices.mockResolvedValue(preheatPrices());
+      mockMel.getDeviceState.mockResolvedValue({
+        RoomTemperature: 20,           // within band -> gate inert, heating possible
+        RoomTemperatureZone1: 20,
+        SetTemperature: 20,
+        SetTemperatureZone1: 20,
+        OutdoorTemperature: 5,
+        IdleZone1: false
+      });
+
+      await optimizer.runOptimization();
+
+      expect(mockMel.setDeviceTemperature).toHaveBeenCalled();
+    });
+  });
+
+  test('persists tank lockout timestamp on a tank-only apply (zone1 not applied)', async () => {
+    // Regression for DHW-3: in summer zone1 never applies, so the tank change must still be
+    // persisted to settings or the anti-cycling lockout is lost on restart.
+    const homey: any = {
+      settings: {
+        get: jest.fn().mockReturnValue(undefined),
+        set: jest.fn()
+      }
+    };
+    optimizer = new Optimizer(mockMel, mockTibber, 'device-1', 1, logger as any, undefined, homey);
+
+    const zone1Result: any = {
+      needsApply: false,        // zone1 holds (summer: room above band / no demand)
+      lockoutActive: false,
+      duplicateTarget: false,
+      changed: false,
+      targetTemp: 20,
+      safeCurrentTarget: 20,
+      tempDifference: 0
+    };
+    const tankResult: any = {
+      needsApply: true,
+      fromTemp: 48,
+      toTemp: 46,
+      evaluatedAtMs: 1700000000000
+    };
+
+    const changes = await (optimizer as any).applySetpointChanges(zone1Result, null, tankResult, jest.fn());
+
+    expect(changes.tankApplied).toBe(true);
+    expect(changes.zone1Applied).toBe(false);
+    expect(mockMel.setTankTemperature).toHaveBeenCalledWith('device-1', 1, 46);
+    // The fix: timestamp persisted even though zone1 did not apply.
+    expect(homey.settings.set).toHaveBeenCalledWith('last_tank_setpoint_change_ms', 1700000000000);
+  });
+
   test('runOptimization forwards device state to the hot water service collector', async () => {
     const collectData = jest.fn().mockResolvedValue(true);
     const getUsageStatistics = jest.fn().mockReturnValue({

--- a/test/unit/temperature-optimizer.test.ts
+++ b/test/unit/temperature-optimizer.test.ts
@@ -498,6 +498,30 @@ describe('TemperatureOptimizer', () => {
         expect(mockCopNormalizer.updateRange).toHaveBeenCalledWith(2.8);
         expect(mockCopNormalizer.updateRange).toHaveBeenCalledWith(2.5);
       });
+
+      it('should NOT apply the low-efficiency penalty when heating COP is unmeasured (Fix 5)', async () => {
+        // Unmeasured: no recent heat output -> realHeatingCOP 0. The -0.4°C penalty must not fire.
+        const unmeasured = createMockMetrics({ seasonalMode: 'transition', realHeatingCOP: 0, realHotWaterCOP: 2.5 });
+        mockCopNormalizer.normalize.mockReturnValue(0); // efficiency 0, but it's a non-measurement
+
+        const unmeasuredResult = await optimizer.calculateOptimalTemperatureWithRealData(
+          defaultPriceStats, 21.0, 12.0, defaultComfortBand, unmeasured
+        );
+
+        // Measured-but-low: real COP present and low -> penalty SHOULD fire.
+        const measuredLow = createMockMetrics({ seasonalMode: 'transition', realHeatingCOP: 1.0, realHotWaterCOP: 2.5 });
+        mockCopNormalizer.normalize.mockReturnValue(0.2); // < TRANSITION_EFFICIENCY_LOW (0.4)
+
+        const measuredLowResult = await optimizer.calculateOptimalTemperatureWithRealData(
+          defaultPriceStats, 21.0, 12.0, defaultComfortBand, measuredLow
+        );
+
+        expect(unmeasuredResult.reason).toMatch(/unmeasured/i);
+        expect(measuredLowResult.reason).toContain('Combined COP efficiency');
+        // The penalty (−0.4°C) only applies to the measured-low case, so it ends up lower.
+        expect(unmeasuredResult.targetTemp).toBeGreaterThan(measuredLowResult.targetTemp);
+        expect(unmeasuredResult.targetTemp - measuredLowResult.targetTemp).toBeCloseTo(0.4, 5);
+      });
     });
 
     // COP-based fine-tuning tests removed: the redundant fine-tuning block was removed


### PR DESCRIPTION
## Context

Two deep audits (space-heating/season + hot-water) of the running production app surfaced confirmed HIGH/MEDIUM correctness issues, verified against live data pulled from the Homey Pro on 2026-06-02. Scope is **surgical, high-value fixes only** — the heating-season behavior works well and is untouched. Two large/behavioral items (DHW usage-pattern production→draw rewrite; seasonal-segregated thermal model) were intentionally **deferred**.

## Fixes

- **DHW-3 (HIGH):** persist tank lockout timestamp on tank-only apply. In summer zone1 never applies, so the tank change was never written to settings → anti-cycling lockout lost on restart (allowing >1 tank change/hour).
- **Season (HIGH):** `determineSeason()` now classifies summer when `heatingProduced ≈ 0` (<0.5 kWh) regardless of standby draw — fixes being stuck in "transition" all summer. Optional param preserves legacy behavior.
- **Heat-demand gate (HIGH):** suppress zone1 setpoint writes when the room is above the comfort band (no heat possible, e.g. solar gain) — stops pointless summer setpoint churn. Surfaced via `heatDemandHold` in the hold reason.
- **COP history (HIGH→MED):** `cop-helper.compute()` and `getWeeklyAverageCOP()` now read the accurate `EnergyCost/Report` totals (with device-state fallback) instead of the often-zero instantaneous `Daily*` fields.
- **Transition COP penalty (MED):** only apply the −0.4°C low-efficiency reduction when heating COP is actually measured (`realHeatingCOP > 0`).
- **DHW reasoning (MED):** action-specific tank reason (delay/heat_now/maintain) instead of a fixed "Predictive scheduling…" template that mislabeled price-driven delays.

## Verification

- `tsc` clean; 6 new/extended unit tests; affected suites **138/138 pass**, optimizer regression sweep **174/174 pass**.
- **Deployed live** via `homey app run` and forced an optimization cycle on the real device:
  - season flipped `transition → summer` ("Summer mode: Hot water COP 2.94")
  - zone1 `no_change` / "Room above comfort band — setpoint has no effect"
  - tank apply now logs "State saved to Homey settings" on a zone1-skipped cycle
  - `getWeeklyAverageCOP.melcloud.hotWater` now 2.94 (was 0)

## Deferred (out of scope)

- DHW usage-pattern rewrite (production→draw, HW-1)
- Seasonal segregation / frozen heatingRate of the thermal model (H4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved COP calculations using aggregated daily energy totals
  * Enhanced seasonal detection for better summer/winter classification

* **Bug Fixes**
  * Suppresses unnecessary temperature adjustments when room exceeds comfort band
  * Fixed efficiency penalty calculation to only apply with measured heating data
  * Strengthened anti-cycling lockout persistence across restarts

* **Tests**
  * Added unit tests covering new functionality and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->