### PR TITLE
chore(release): v14.0.54 — season/DHW/COP audit fixes

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -265,5 +265,8 @@
   },
   "14.0.53": {
     "en": "Bug hunting"
+  },
+  "14.0.54": {
+    "en": "Summer fix: no longer stuck in \"transition\" when there's no heating; stop redundant room setpoint changes when the house is already warm; more accurate COP history; clearer hot-water reasons."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.melcloud.optimize",
-  "version": "14.0.53",
+  "version": "14.0.54",
   "compatibility": ">=12.2.0",
   "sdk": 3,
   "platforms": [

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.melcloud.optimize",
-  "version": "14.0.53",
+  "version": "14.0.54",
   "compatibility": ">=12.2.0",
   "sdk": 3,
   "platforms": [


### PR DESCRIPTION
Release metadata for the audit fixes merged in #57.

- Bumps version `14.0.53 → 14.0.54` (`.homeycompose/app.json` + generated `app.json`)
- Adds `.homeychangelog.json` entry for 14.0.54:
  > Summer fix: no longer stuck in "transition" when there's no heating; stop redundant room setpoint changes when the house is already warm; more accurate COP history; clearer hot-water reasons.

Merge this, then run `homey app publish` from `main` to release to the App Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)